### PR TITLE
Support Spring Boot Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,20 @@
                                 <includes>
                                     <include>**/adminjvm/**</include>
                                 </includes>
+                                <excludes>
+                                    <exclude>**/boot/**</exclude>
+                                </excludes>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>admin-only-spring-boot-test</id>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>**/adminjvm/**/boot/**</include>
+                                </includes>
                             </configuration>
                         </execution>
                         <execution>
@@ -152,6 +166,20 @@
                             <configuration>
                                 <includes>
                                     <include>**/sitejvm/**</include>
+                                </includes>
+                                <excludes>
+                                    <exclude>**/boot/**</exclude>
+                                </excludes>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>site-only-spring-boot-test</id>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>**/sitejvm/**/boot/**</include>
                                 </includes>
                             </configuration>
                         </execution>


### PR DESCRIPTION
BroadleafCommerce/QA#2946

- Support separate JVMs for regular admin and spring boot admin contexts. DirtiesContext is not enough, since the spring boot test will necessarily re-initialize and there will be clashes on some static variables.