### PR TITLE
Update Animal Sniffer to handle Java 9+ jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.16</version>
+                <version>1.18</version>
                 <executions>
                     <execution>
                         <id>sniff</id>


### PR DESCRIPTION
Without this, you end up with an exception on compilation like this one:

```console
[ERROR] Failed to execute goal org.codehaus.mojo:animal-sniffer-maven-plugin:1.16:check (sniff) on project broadleaf-enterprise: Failed to check signatures:  failed to process jar /Users/kellytisdell/.m2/repository/org/springframework/session/spring-session-core/2.1.3.RELEASE/spring-session-core-2.1.3.RELEASE.jar : invalid LOC header (bad signature) -> [Help 1]
```