### PR TITLE
Prevent the Maven Source Plugin from executing multiple times on releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -639,23 +639,6 @@
             </build>
         </profile>
         <profile>
-            <id>build-sources</id>
-            <activation>
-                <property>
-                    <name>attachSources</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>security-check</id>
             <build>
                 <plugins>


### PR DESCRIPTION
In later versions of Maven this will generate 2 artifacts which will cause Nexus to throw a 400 on the attempt of uploading the 2nd artifact, as they are both attached to the release