### PR TITLE
Do not rely on performRelease=true to activate release profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -633,12 +633,6 @@
         </profile>
         <profile>
             <id>javadocs</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -650,12 +644,6 @@
         </profile>
         <profile>
             <id>sources</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
As a continuation of gh-6, this adds a bit of future-proofing for when Maven might remove the existing plugins, and allows us to maintain backwards-compatibility with our legacy build pipelines. Now, when we build, we can turn off performRelease=true and not get duplicate source artifacts when releasing projects that are not up to date with this ModuleParent