### PR TITLE
Replace Bintray repository with Spring Plugins Releases in order to resolve TestNG 6.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
             https://groups.google.com/forum/#!topic/testng-users/nIGIqKliavM discussion for the latest
 			status -->
         <repository>
-            <id>jcenter</id>
-            <name>jcenter</name>
-            <url>https://jcenter.bintray.com</url>
+            <id>Spring Plugins Release</id>
+            <name>Spring Plugins Release</name>
+            <url>https://repo.spring.io/plugins-release/</url>
         </repository>
     </repositories>
     <properties>


### PR DESCRIPTION
Replace bintray repository with spring plugins release repository since bintray has now removed TestNG 6.12 along with Maven Central.

This only affects the BLC 5.2 line as all other versions of TestNG can be resolved through Maven Central and no other line uses TestNG 6.12