### PR TITLE
Migrate from Java EE to Jakarta EE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,13 @@
         <spock.spring.version>1.1-groovy-2.4</spock.spring.version>
         <spock.core.version>1.1-groovy-2.4</spock.core.version>
         <spring.test.version>6.0.6</spring.test.version>
-        <spring.instrument.version>6.0.6</spring.instrument.version>
+        <spring.version>6.0.6</spring.version>
         <spring.boot.test.version>3.0.4</spring.boot.test.version>
         <jackson.version>2.14.2</jackson.version>
         <lombok.version>1.18.24</lombok.version>
         <hsqldb.version>2.7.1</hsqldb.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
+        <jakarta.version>6.0.0</jakarta.version>
     </properties>
     <scm>
         <connection>scm:git:git@github.com:BroadleafCommerce/ModuleParent.git</connection>
@@ -363,7 +364,7 @@
                                 <artifactItem>
                                     <groupId>org.springframework</groupId>
                                     <artifactId>spring-instrument</artifactId>
-                                    <version>${spring.instrument.version}</version>
+                                    <version>${spring.version}</version>
                                     <outputDirectory>${project.build.directory}/agents</outputDirectory>
                                     <destFileName>spring-instrument.jar</destFileName>
                                 </artifactItem>
@@ -664,7 +665,7 @@
             <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
-                <version>5.0.0</version>
+                <version>${jakarta.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -678,6 +678,7 @@
                 <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
                 <version>${groovy.version}</version>
+                <type>pom</type>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.1.0</version>
                     <executions>
                         <execution>
                             <id>default-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -680,6 +680,12 @@
                 <version>${groovy.version}</version>
                 <type>pom</type>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.yaml</groupId>
+                        <artifactId>snakeyaml</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -697,6 +703,10 @@
                         <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -708,6 +718,10 @@
                     <exclusion>
                         <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.1.0</version>
                     <executions>
                         <execution>
                             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
                     <configuration>
                         <reuseForks>false</reuseForks>
                         <argLine>
-                            -Xmx1g
+                            -Xmx2g
                             -javaagent:"${project.build.directory}/agents/spring-instrument.jar"
                             @{surefire.argLine}
                         </argLine>
@@ -216,7 +216,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.8</version>
+                    <version>0.8.10</version>
                     <executions>
                         <!-- Unit test coverage prep; generates jacoco.exec -->
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <attachSources>true</attachSources>
-        <groovy.version>2.4.15</groovy.version>
-        <spock.spring.version>1.1-groovy-2.4</spock.spring.version>
-        <spock.core.version>1.1-groovy-2.4</spock.core.version>
+        <groovy.version>4.0.11</groovy.version>
+        <spock.spring.version>2.4-M1-groovy-4.0</spock.spring.version>
+        <spock.core.version>2.4-M1-groovy-4.0</spock.core.version>
         <spring.test.version>6.0.8</spring.test.version>
         <spring.version>6.0.8</spring.version>
         <spring.boot.test.version>3.0.6</spring.boot.test.version>
@@ -675,7 +675,7 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
                 <version>${groovy.version}</version>
                 <scope>test</scope>
@@ -693,7 +693,7 @@
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.codehaus.groovy</groupId>
+                        <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
                     </exclusion>
                 </exclusions>
@@ -705,7 +705,7 @@
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.codehaus.groovy</groupId>
+                        <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
                     </exclusion>
                 </exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <groovy.version>4.0.12</groovy.version>
         <spock.spring.version>2.4-M1-groovy-4.0</spock.spring.version>
         <spock.core.version>2.4-M1-groovy-4.0</spock.core.version>
-        <spring.test.version>6.0.8</spring.test.version>
-        <spring.version>6.0.8</spring.version>
+        <spring.test.version>6.0.9</spring.test.version>
+        <spring.version>6.0.9</spring.version>
         <spring.boot.test.version>3.0.7</spring.boot.test.version>
         <jackson.version>2.15.0</jackson.version>
         <lombok.version>1.18.24</lombok.version>
@@ -741,7 +741,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.13.1</version>
+                <version>4.13.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -757,6 +757,12 @@
                 <classifier>jdk8</classifier>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>1.14.5</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.2</version>
                     <executions>
                         <execution>
                             <id>default-test</id>
@@ -194,7 +194,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.2</version>
                     <executions>
                         <execution>
                             <goals>
@@ -692,6 +692,20 @@
                 <artifactId>spring-boot-starter-test</artifactId>
                 <version>${spring.boot.test.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.spockframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
         <groovy.version>2.4.15</groovy.version>
         <spock.spring.version>1.1-groovy-2.4</spock.spring.version>
         <spock.core.version>1.1-groovy-2.4</spock.core.version>
-        <spring.test.version>6.0.6</spring.test.version>
-        <spring.version>6.0.6</spring.version>
-        <spring.boot.test.version>3.0.4</spring.boot.test.version>
+        <spring.test.version>6.0.8</spring.test.version>
+        <spring.version>6.0.8</spring.version>
+        <spring.boot.test.version>3.0.6</spring.boot.test.version>
         <jackson.version>2.14.2</jackson.version>
         <lombok.version>1.18.24</lombok.version>
         <hsqldb.version>2.7.1</hsqldb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <attachSources>true</attachSources>
-        <groovy.version>4.0.11</groovy.version>
+        <groovy.version>4.0.12</groovy.version>
         <spock.spring.version>2.4-M1-groovy-4.0</spock.spring.version>
         <spock.core.version>2.4-M1-groovy-4.0</spock.core.version>
         <spring.test.version>6.0.8</spring.test.version>
         <spring.version>6.0.8</spring.version>
         <spring.boot.test.version>3.0.6</spring.boot.test.version>
-        <jackson.version>2.14.2</jackson.version>
+        <jackson.version>2.15.0</jackson.version>
         <lombok.version>1.18.24</lombok.version>
         <hsqldb.version>2.7.1</hsqldb.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
         <groovy.version>2.4.15</groovy.version>
         <spock.spring.version>1.1-groovy-2.4</spock.spring.version>
         <spock.core.version>1.1-groovy-2.4</spock.core.version>
-        <spring.test.version>5.3.23</spring.test.version>
-        <spring.instrument.version>5.3.23</spring.instrument.version>
-        <spring.boot.test.version>2.7.5</spring.boot.test.version>
-        <jackson.version>2.13.4</jackson.version>
+        <spring.test.version>6.0.6</spring.test.version>
+        <spring.instrument.version>6.0.6</spring.instrument.version>
+        <spring.boot.test.version>3.0.4</spring.boot.test.version>
+        <jackson.version>2.14.2</jackson.version>
         <lombok.version>1.18.24</lombok.version>
         <hsqldb.version>2.7.1</hsqldb.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
@@ -345,27 +345,6 @@
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.18</version>
-                <executions>
-                    <execution>
-                        <id>sniff</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java18</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
             </plugin>
             <plugin>
@@ -683,9 +662,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>4.0.1</version>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>5.0.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.9</version>
+                    <version>0.8.8</version>
                     <executions>
                         <!-- Unit test coverage prep; generates jacoco.exec -->
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -705,6 +705,10 @@
                         <groupId>jakarta.activation</groupId>
                         <artifactId>jakarta.activation-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.11.0</version>
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
@@ -647,7 +647,7 @@
                     <plugin>
                       <groupId>org.owasp</groupId>
                       <artifactId>dependency-check-maven</artifactId>
-                      <version>3.2.0</version>
+                      <version>8.1.2</version>
                       <executions>
                           <execution>
                               <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <spock.core.version>2.4-M1-groovy-4.0</spock.core.version>
         <spring.test.version>6.0.8</spring.test.version>
         <spring.version>6.0.8</spring.version>
-        <spring.boot.test.version>3.0.6</spring.boot.test.version>
+        <spring.boot.test.version>3.0.7</spring.boot.test.version>
         <jackson.version>2.15.0</jackson.version>
         <lombok.version>1.18.24</lombok.version>
         <hsqldb.version>2.7.1</hsqldb.version>


### PR DESCRIPTION
**Description**
For a correct migration from Java EE to Jakarta EE, needed to update the parent module:
- update spring, spring-boot, jackson versions; 
- replace javax with jakarta; 
- remove animal-sniffer-maven-plugin

**QA Link**
[QA-4929](https://github.com/BroadleafCommerce/QA/issues/4929)