### PR TITLE
Removed byte-buddy dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -733,6 +733,10 @@
                         <groupId>org.junit.platform</groupId>
                         <artifactId>junit-platform-engine</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -810,12 +814,6 @@
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
                 <version>${hsqldb.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>1.14.12</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
**A Brief Overview**
Removed byte-buddy dependency
 
**Link to QA issue**
[QA-5270](https://github.com/BroadleafCommerce/QA/issues/5270)